### PR TITLE
Add Blacklist Brand to use Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
-## 1.1.2 - February 21, 2024
+## 1.2.0 - April 2, 2024
+* Fix [Issue 1](https://github.com/chandrabezzo/flutter_dynamic_icon_plus/issues/1), after check more detail found [problem](https://stackoverflow.com/questions/40660216/ontaskremoved-not-getting-called-in-huawei-and-xiaomi-devices) for specific device/brand. So, need to add parameters `blacklistBrands` on `setAlternateIconName` to add blacklist brand that can't works with Service.
+* For blacklist brands will use approach force restart app to change the app icon with alternative icon on Android
 
+## 1.1.2 - February 21, 2024
 * Update Readme
 
 ## 1.1.1 - February 21, 2024
-
 * To decrease bad experience user in Android, just change app icon on app closed via [Service](https://developer.android.com/develop/background-work/services)
 
 
 ## 1.1.0 - February 21, 2024
-
 * To decrease bad experience user in Android, just change app icon on app closed via [Service](https://developer.android.com/develop/background-work/services)
 
 ## 1.0.0 - February 19, 2024
-
 * Dynamic App Icon on Android and iOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.0 - April 2, 2024
-* Fix [Issue 1](https://github.com/chandrabezzo/flutter_dynamic_icon_plus/issues/1), after check more detail found [problem](https://stackoverflow.com/questions/40660216/ontaskremoved-not-getting-called-in-huawei-and-xiaomi-devices) for specific device/brand. So, need to add parameters `blacklistBrands` on `setAlternateIconName` to add blacklist brand that can't works with Service.
-* For blacklist brands will use approach force restart app to change the app icon with alternative icon on Android
+* Fix [Issue 1](https://github.com/chandrabezzo/flutter_dynamic_icon_plus/issues/1), after check more detail found [problem](https://stackoverflow.com/questions/40660216/ontaskremoved-not-getting-called-in-huawei-and-xiaomi-devices) for specific device/brand. So, need to add parameters `blacklistBrands`, `blacklistManufactures`, and `blacklistModels` on `setAlternateIconName` to add blacklist brand that can't works with Service.
+* For blacklist brands, manufactures, and models will use approach force restart app to change the app icon with alternative icon on Android
 
 ## 1.1.2 - February 21, 2024
 * Update Readme

--- a/android/src/main/kotlin/com/solusibejo/flutter_dynamic_icon_plus/Arguments.kt
+++ b/android/src/main/kotlin/com/solusibejo/flutter_dynamic_icon_plus/Arguments.kt
@@ -2,4 +2,5 @@ package com.solusibejo.flutter_dynamic_icon_plus
 
 object Arguments {
     const val iconName = "iconName"
+    const val brands = "brands"
 }

--- a/android/src/main/kotlin/com/solusibejo/flutter_dynamic_icon_plus/Arguments.kt
+++ b/android/src/main/kotlin/com/solusibejo/flutter_dynamic_icon_plus/Arguments.kt
@@ -3,4 +3,6 @@ package com.solusibejo.flutter_dynamic_icon_plus
 object Arguments {
     const val iconName = "iconName"
     const val brands = "brands"
+    const val manufactures = "manufactures"
+    const val models = "models"
 }

--- a/android/src/main/kotlin/com/solusibejo/flutter_dynamic_icon_plus/FlutterDynamicIconPlusPlugin.kt
+++ b/android/src/main/kotlin/com/solusibejo/flutter_dynamic_icon_plus/FlutterDynamicIconPlusPlugin.kt
@@ -1,12 +1,9 @@
 package com.solusibejo.flutter_dynamic_icon_plus
 
 import android.app.Activity
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.ServiceConnection
 import android.os.Build
-import android.os.IBinder
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -42,22 +39,12 @@ class FlutterDynamicIconPlusPlugin: FlutterPlugin, MethodCallHandler, ActivityAw
           val sp = activity?.getSharedPreferences(pluginName, Context.MODE_PRIVATE)
           val iconName = call.argument<String?>(Arguments.iconName)
           val brandsInString = call.argument<String?>(Arguments.brands)
-          val brands = brandsInString?.split(",")?.toList()
+          val manufacturesInString = call.argument<String?>(Arguments.manufactures)
+          val modelsInString = call.argument<String?>(Arguments.models)
 
           sp?.edit()?.putString(appIcon, iconName)?.apply()
 
-          val deviceBrand = Build.BRAND
-          var isBrandBlacklist = false
-          if (brands != null) {
-            for(brand in brands){
-              if(deviceBrand.equals(brand, ignoreCase = true)){
-                isBrandBlacklist = true
-                break
-              }
-            }
-          }
-
-          if(isBrandBlacklist){
+          if(containsOnBlacklist(brandsInString, manufacturesInString, modelsInString)){
             if(activity != null){
               ComponentUtil.changeAppIcon(activity!!, activity!!.packageManager, activity!!.packageName)
 
@@ -100,6 +87,41 @@ class FlutterDynamicIconPlusPlugin: FlutterPlugin, MethodCallHandler, ActivityAw
         result.notImplemented()
       }
     }
+  }
+
+  fun containsOnBlacklist(brandsInString: String?, manufacturesInString: String?, modelsInString: String?): Boolean {
+    val brands = brandsInString?.split(",")?.toList()
+    val manufactures = manufacturesInString?.split(',')?.toList()
+    val models = modelsInString?.split(',')?.toList()
+
+    val deviceBrand = Build.BRAND
+    val deviceManufacture = Build.MANUFACTURER
+    val deviceModel = Build.MODEL
+
+    if (brands != null) {
+      for(brand in brands){
+        if(deviceBrand.equals(brand, ignoreCase = true)){
+          return true
+        }
+      }
+    }
+
+    if(manufactures != null){
+      for(manufacture in manufactures){
+        if(deviceManufacture.equals(manufacture, ignoreCase = true)){
+          return true
+        }
+      }
+    }
+
+    if(models != null){
+      for(model in models){
+        if(deviceModel.equals(model, ignoreCase = true))
+          return true
+      }
+    }
+
+    return false
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/android/src/main/kotlin/com/solusibejo/flutter_dynamic_icon_plus/FlutterDynamicIconPlusService.kt
+++ b/android/src/main/kotlin/com/solusibejo/flutter_dynamic_icon_plus/FlutterDynamicIconPlusService.kt
@@ -13,50 +13,11 @@ class FlutterDynamicIconPlusService: Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        changeAppIcon()
+        ComponentUtil.changeAppIcon(this, packageManager, packageName)
 
-        val sp = getSharedPreferences(FlutterDynamicIconPlusPlugin.pluginName, Context.MODE_PRIVATE)
-        sp.edit()?.remove(FlutterDynamicIconPlusPlugin.appIcon)?.apply()
+        ComponentUtil.removeCurrentAppIcon(this)
 
         super.onTaskRemoved(rootIntent)
         stopSelf()
-    }
-
-    private fun changeAppIcon(){
-        val sp = getSharedPreferences(FlutterDynamicIconPlusPlugin.pluginName, Context.MODE_PRIVATE)
-        sp.getString(FlutterDynamicIconPlusPlugin.appIcon, null).let { name ->
-            val currentlyEnabled = ComponentUtil.getCurrentEnabledAlias(this)
-            if(currentlyEnabled?.name != name){
-                setupIcon(name, currentlyEnabled?.name)
-            }
-        }
-    }
-
-    private fun setupIcon(newName: String?, currentlyName: String?){
-        val components: List<ComponentName> = ComponentUtil.getComponentNames(this, newName)
-
-        for (component in components) {
-            if (currentlyName != null && currentlyName == component.className) return
-            Log.d(
-                "setAlternateIconName",
-                String.format(
-                    "Changing enabled activity-alias from %s to %s",
-                    currentlyName ?: "default", component.className
-                )
-            )
-            ComponentUtil.enable(this, packageManager, component.className)
-        }
-
-        val componentsToDisable: List<ComponentName> = if (currentlyName != null) {
-            listOf(
-                ComponentName(packageName, currentlyName)
-            )
-        } else {
-            ComponentUtil.getComponentNames(this, null)
-        }
-
-        for (toDisable in componentsToDisable) {
-            ComponentUtil.disable(this, packageManager, toDisable.className)
-        }
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,6 +18,7 @@ class MyAppState extends State<MyApp> {
   int batchIconNumber = 0;
 
   String currentIconName = "?";
+  final blacklistBrands = ['redmi'];
 
   bool loading = false;
   bool showAlert = true;
@@ -158,7 +159,10 @@ class MyAppState extends State<MyApp> {
               onPressed: () async {
                 try {
                   if (await FlutterDynamicIconPlus.supportsAlternateIcons) {
-                    await FlutterDynamicIconPlus.setAlternateIconName("chills");
+                    await FlutterDynamicIconPlus.setAlternateIconName(
+                      iconName: "chills",
+                      blacklistBrands: blacklistBrands,
+                    );
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).hideCurrentSnackBar();
                       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
@@ -190,7 +194,10 @@ class MyAppState extends State<MyApp> {
               onPressed: () async {
                 try {
                   if (await FlutterDynamicIconPlus.supportsAlternateIcons) {
-                    await FlutterDynamicIconPlus.setAlternateIconName("photos");
+                    await FlutterDynamicIconPlus.setAlternateIconName(
+                      iconName: 'photos',
+                      blacklistBrands: blacklistBrands,
+                    );
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).hideCurrentSnackBar();
                       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
@@ -227,7 +234,9 @@ class MyAppState extends State<MyApp> {
                       'Supports Alternate Icons: ${isSupport.toString()}');
                   if (isSupport) {
                     await FlutterDynamicIconPlus.setAlternateIconName(
-                        "teamfortress");
+                      iconName: 'teamfortress',
+                      blacklistBrands: blacklistBrands,
+                    );
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).hideCurrentSnackBar();
                       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
@@ -262,7 +271,10 @@ class MyAppState extends State<MyApp> {
               onPressed: () async {
                 try {
                   if (await FlutterDynamicIconPlus.supportsAlternateIcons) {
-                    await FlutterDynamicIconPlus.setAlternateIconName(null);
+                    await FlutterDynamicIconPlus.setAlternateIconName(
+                      iconName: null,
+                      blacklistBrands: blacklistBrands,
+                    );
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).hideCurrentSnackBar();
                       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -90,6 +90,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: b068ffc46f82a55844acfa4fdbb61fad72fa2aef0905548419d97f0f95c456da
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.17"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -280,4 +288,4 @@ packages:
     version: "3.0.3"
 sdks:
   dart: ">=3.2.6 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.7.0"

--- a/lib/flutter_dynamic_icon_plus.dart
+++ b/lib/flutter_dynamic_icon_plus.dart
@@ -9,9 +9,15 @@ class FlutterDynamicIconPlus {
   static Future<String?> get alternateIconName async =>
       await FlutterDynamicIconPlusPlatform.instance.alternateIconName;
 
-  static Future<void> setAlternateIconName(String? iconName) async =>
-      await FlutterDynamicIconPlusPlatform.instance
-          .setAlternateIconName(iconName);
+  static Future<void> setAlternateIconName({
+    String? iconName,
+    List<String> blacklistBrands = const [],
+  }) async {
+    await FlutterDynamicIconPlusPlatform.instance.setAlternateIconName(
+      iconName: iconName,
+      blacklistBrands: blacklistBrands,
+    );
+  }
 
   static Future<int> get applicationIconBadgeNumber async =>
       await FlutterDynamicIconPlusPlatform.instance.applicationIconBadgeNumber;

--- a/lib/flutter_dynamic_icon_plus.dart
+++ b/lib/flutter_dynamic_icon_plus.dart
@@ -9,13 +9,19 @@ class FlutterDynamicIconPlus {
   static Future<String?> get alternateIconName async =>
       await FlutterDynamicIconPlusPlatform.instance.alternateIconName;
 
+  /// `blacklistBrands`, `blacklistManufactures`, `blacklistModels` just only
+  /// work for Android platform only
   static Future<void> setAlternateIconName({
     String? iconName,
     List<String> blacklistBrands = const [],
+    List<String> blacklistManufactures = const [],
+    List<String> blacklistModels = const [],
   }) async {
     await FlutterDynamicIconPlusPlatform.instance.setAlternateIconName(
       iconName: iconName,
       blacklistBrands: blacklistBrands,
+      blacklistManufactures: blacklistManufactures,
+      blacklistModels: blacklistModels,
     );
   }
 

--- a/lib/flutter_dynamic_icon_plus_method_channel.dart
+++ b/lib/flutter_dynamic_icon_plus_method_channel.dart
@@ -27,10 +27,17 @@ class MethodChannelFlutterDynamicIconPlus
   }
 
   @override
-  Future<void> setAlternateIconName(String? iconName) async {
+  Future<void> setAlternateIconName({
+    String? iconName,
+    List<String> blacklistBrands = const [],
+  }) async {
+    final brands = blacklistBrands.join(',');
     await methodChannel.invokeMethod(
       MethodNames.setAlternateIconName,
-      {Arguments.iconName: iconName},
+      {
+        Arguments.iconName: iconName,
+        Arguments.brands: brands,
+      },
     );
   }
 

--- a/lib/flutter_dynamic_icon_plus_method_channel.dart
+++ b/lib/flutter_dynamic_icon_plus_method_channel.dart
@@ -30,13 +30,20 @@ class MethodChannelFlutterDynamicIconPlus
   Future<void> setAlternateIconName({
     String? iconName,
     List<String> blacklistBrands = const [],
+    List<String> blacklistManufactures = const [],
+    List<String> blacklistModels = const [],
   }) async {
     final brands = blacklistBrands.join(',');
+    final manufactures = blacklistManufactures.join(',');
+    final models = blacklistModels.join(',');
+
     await methodChannel.invokeMethod(
       MethodNames.setAlternateIconName,
       {
         Arguments.iconName: iconName,
         Arguments.brands: brands,
+        Arguments.manufactures: manufactures,
+        Arguments.models: models,
       },
     );
   }

--- a/lib/flutter_dynamic_icon_plus_platform_interface.dart
+++ b/lib/flutter_dynamic_icon_plus_platform_interface.dart
@@ -33,6 +33,8 @@ abstract class FlutterDynamicIconPlusPlatform extends PlatformInterface {
   Future<void> setAlternateIconName({
     String? iconName,
     List<String> blacklistBrands = const [],
+    List<String> blacklistManufactures = const [],
+    List<String> blacklistModels = const [],
   }) =>
       throw UnimplementedError(
           'setAlternateIconName(String? iconName) has not been implemented.');

--- a/lib/flutter_dynamic_icon_plus_platform_interface.dart
+++ b/lib/flutter_dynamic_icon_plus_platform_interface.dart
@@ -30,7 +30,10 @@ abstract class FlutterDynamicIconPlusPlatform extends PlatformInterface {
   Future<String?> get alternateIconName =>
       throw UnimplementedError('alternateIconName has not been implemented.');
 
-  Future<void> setAlternateIconName(String? iconName) =>
+  Future<void> setAlternateIconName({
+    String? iconName,
+    List<String> blacklistBrands = const [],
+  }) =>
       throw UnimplementedError(
           'setAlternateIconName(String? iconName) has not been implemented.');
 

--- a/lib/src/consts/arguments.dart
+++ b/lib/src/consts/arguments.dart
@@ -1,5 +1,6 @@
 class Arguments {
   static const iconName = 'iconName';
+  static const brands = 'brands';
   static const enabledIconName = 'enabledIconName';
   static const batchIconNumber = 'batchIconNumber';
 }

--- a/lib/src/consts/arguments.dart
+++ b/lib/src/consts/arguments.dart
@@ -1,6 +1,8 @@
 class Arguments {
   static const iconName = 'iconName';
   static const brands = 'brands';
+  static const manufactures = 'manufactures';
+  static const models = 'models';
   static const enabledIconName = 'enabledIconName';
   static const batchIconNumber = 'batchIconNumber';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_plugin_android_lifecycle: ^2.0.17
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_dynamic_icon_plus
 description: "A flutter plugin for dynamically changing app icon, support IOS version > 10.3 and Android"
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/chandrabezzo/flutter_dynamic_icon_plus
 repository: https://github.com/chandrabezzo/flutter_dynamic_icon_plus
 issue_tracker: https://github.com/chandrabezzo/flutter_dynamic_icon_plus/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_plugin_android_lifecycle: ^2.0.17
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:


### PR DESCRIPTION
* Fix #1, after check more detail found [problem](https://stackoverflow.com/questions/40660216/ontaskremoved-not-getting-called-in-huawei-and-xiaomi-devices) for specific device/brand. So, need to add parameters `blacklistBrands` on `setAlternateIconName` to add blacklist brand that can't works with Service.
* For blacklist brands will use approach force restart app to change the app icon with alternative icon on Android