### PR TITLE
fix(ios) remove SwiftTryCatch dependency

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -109,26 +109,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -141,26 +141,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -250,18 +250,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -279,5 +279,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/FlutterDynamicIconPlusPlugin.swift
+++ b/ios/Classes/FlutterDynamicIconPlusPlugin.swift
@@ -1,6 +1,5 @@
 import Flutter
 import UIKit
-import SwiftTryCatch
 
 public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -27,30 +26,14 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
             }
         case MethodNames.setAlternateIconName:
             if #available(iOS 10.3, *){
-                SwiftTryCatch.try {
-                    let args = call.arguments as! [String: Any]
-                    var iconName = args[Arguments.iconName]
-                    let isSilent = args[Arguments.isSilent]
-                    
-                    if (iconName == nil) {
-                        iconName = nil
-                    }
-                    
-                    if let isSilent = isSilent as? Bool, isSilent {
-                        self.setIconWithoutAlert(iconName as? String, result: result)
-                    } else {
-                        self.setIconWithAlert(iconName as? String, result: result)
-                    }
-                } catch: { (exception) in
-                    let errorReason = exception?.reason ?? "Unknown Error setAlternateIconName"
-                    print("\(errorReason)")
-                    result(
-                        FlutterError(
-                            code: "Failed to set icon: \(errorReason)",
-                            message: errorReason,
-                            details: nil))
-                } finally: {
-                    result(nil)
+                let args = call.arguments as! [String: Any]
+                let iconName = args[Arguments.iconName] as? String
+                let isSilent = args[Arguments.isSilent]
+
+                if let isSilent = isSilent as? Bool, isSilent {
+                    self.setIconWithoutAlert(iconName, result: result)
+                } else {
+                    self.setIconWithAlert(iconName, result: result)
                 }
             }
             else {
@@ -69,39 +52,15 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
                 if #available(iOS 10.0, *) {
                     UNUserNotificationCenter.current().requestAuthorization(options: .badge) { granted, error in
                         if granted {
-                            SwiftTryCatch.try {
-                                let batchIconNumber = (args[Arguments.batchIconNumber] as? NSNumber)?.intValue ?? 0
-                                UIApplication.shared.applicationIconBadgeNumber = batchIconNumber
-                                result(nil)
-                            } catch: { (exception) in
-                                let errorReason = exception?.reason ?? "Unknown Error setApplicationIconBadgNumber"
-                                print("\(errorReason)")
-                                result(
-                                    FlutterError(
-                                        code: "Failed to set batch icon number",
-                                        message: errorReason,
-                                        details: nil))
-                            } finally: {
-                                result(nil)
-                            }
+                            let batchIconNumber = (args[Arguments.batchIconNumber] as? NSNumber)?.intValue ?? 0
+                            UIApplication.shared.applicationIconBadgeNumber = batchIconNumber
+                            result(nil)
                         }
                         else {
-                            SwiftTryCatch.try {
-                                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) {
-                                    (granted, error) in
-                                    let batchIconNumber = (args[Arguments.batchIconNumber] as? NSNumber)?.intValue ?? 0
-                                    UIApplication.shared.applicationIconBadgeNumber = batchIconNumber
-                                    result(nil)
-                                }
-                            } catch: { (exception) in
-                                let errorReason = exception?.reason ?? "Unknown Error setApplicationIconBadgeNumber"
-                                print("\(errorReason)")
-                                result(
-                                    FlutterError(
-                                        code: "Failed to set icon",
-                                        message: errorReason,
-                                        details: nil))
-                            } finally: {
+                            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) {
+                                (granted, error) in
+                                let batchIconNumber = (args[Arguments.batchIconNumber] as? NSNumber)?.intValue ?? 0
+                                UIApplication.shared.applicationIconBadgeNumber = batchIconNumber
                                 result(nil)
                             }
                         }
@@ -116,24 +75,11 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
                 }
             }
             else {
-                SwiftTryCatch.try {
-                    let notificationSettings = UIUserNotificationSettings(types: .badge, categories: nil)
-                    
-                    UIApplication.shared.registerUserNotificationSettings(notificationSettings)
-                    let batchIconNumber = (args[Arguments.batchIconNumber] as? NSNumber)?.intValue ?? 0
-                    UIApplication.shared.applicationIconBadgeNumber = batchIconNumber
-                    result(nil)
-                } catch: { (exception) in
-                    let errorReason = exception?.reason ?? "Unknown Error setApplicationIconBadgeNumber"
-                    print(errorReason)
-                    result(
-                        FlutterError(
-                            code: "Failed to set batch icon number",
-                            message: errorReason,
-                            details: nil))
-                } finally : {
-                    result(nil)
-                }
+                let notificationSettings = UIUserNotificationSettings(types: .badge, categories: nil)
+                UIApplication.shared.registerUserNotificationSettings(notificationSettings)
+                let batchIconNumber = (args[Arguments.batchIconNumber] as? NSNumber)?.intValue ?? 0
+                UIApplication.shared.applicationIconBadgeNumber = batchIconNumber
+                result(nil)
             }
         default:
             result(FlutterMethodNotImplemented)

--- a/ios/Classes/FlutterDynamicIconPlusPlugin.swift
+++ b/ios/Classes/FlutterDynamicIconPlusPlugin.swift
@@ -26,7 +26,10 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
             }
         case MethodNames.setAlternateIconName:
             if #available(iOS 10.3, *){
-                let args = call.arguments as! [String: Any]
+                guard let args = call.arguments as? [String: Any] else {
+                    result(FlutterError(code: "InvalidArguments", message: "Missing or invalid arguments for setAlternateIconName", details: nil))
+                    return
+                }
                 let iconName = args[Arguments.iconName] as? String
                 let isSilent = args[Arguments.isSilent]
 
@@ -47,7 +50,10 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
                 result(FlutterError(code: "Unavailable", message: "Method getApplicationIconBadgeNumber unsupported on iOS version < 10.3", details: nil))
             }
         case MethodNames.setApplicationIconBadgeNumber:
-            let args = call.arguments as! [String: Any]
+            guard let args = call.arguments as? [String: Any] else {
+                result(FlutterError(code: "InvalidArguments", message: "Missing or invalid arguments for setApplicationIconBadgeNumber", details: nil))
+                return
+            }
             if #available(iOS 10.3, *){
                 if #available(iOS 10.0, *) {
                     UNUserNotificationCenter.current().requestAuthorization(options: .badge) { granted, error in

--- a/ios/flutter_dynamic_icon_plus.podspec
+++ b/ios/flutter_dynamic_icon_plus.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'SwiftTryCatch'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
Summary                                                   

  - Removed the SwiftTryCatch third-party dependency from the iOS plugin, simplifying error handling and reducing the dependency footprint
  - Replaced all SwiftTryCatch.try/catch/finally blocks with direct Swift code in FlutterDynamicIconPlusPlugin.swift
  - Removed s.dependency 'SwiftTryCatch' from flutter_dynamic_icon_plus.podspec
  - Added GitHub Actions workflow for automated publishing to pub.dev on version tags
  - Bumped version to 1.4.0

  Why

  SwiftTryCatch is an Objective-C bridging library used to catch NSExceptions in Swift. However, none of the iOS APIs used by this plugin (setAlternateIconName, badge number, etc.) throw NSExceptions — they use
  completion handlers and optional error parameters instead. The dependency added unnecessary complexity and an extra pod install step for consumers.

  Changes

  - ios/Classes/FlutterDynamicIconPlusPlugin.swift — Removed import SwiftTryCatch and replaced all try/catch/finally blocks with direct Swift calls
  - ios/flutter_dynamic_icon_plus.podspec — Removed s.dependency 'SwiftTryCatch'
  - .github/workflows/publish.yml — Added automated pub.dev publish workflow
  - pubspec.yaml — Version bump 1.3.1 → 1.4.0
  - CHANGELOG.md — Added 1.4.0 entry
  - example/pubspec.lock — Updated lockfile