### PR TITLE
fix(ios): drop optional chaining on non-optional NSException in SwiftTryCatch catch blocks

### DIFF
--- a/ios/Classes/FlutterDynamicIconPlusPlugin.swift
+++ b/ios/Classes/FlutterDynamicIconPlusPlugin.swift
@@ -42,7 +42,7 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
                         self.setIconWithAlert(iconName as? String, result: result)
                     }
                 } catch: { (exception) in
-                    let errorReason = exception?.reason ?? "Unknown Error setAlternateIconName"
+                    let errorReason = exception.reason ?? "Unknown Error setAlternateIconName"
                     print("\(errorReason)")
                     result(
                         FlutterError(
@@ -74,7 +74,7 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
                                 UIApplication.shared.applicationIconBadgeNumber = batchIconNumber
                                 result(nil)
                             } catch: { (exception) in
-                                let errorReason = exception?.reason ?? "Unknown Error setApplicationIconBadgNumber"
+                                let errorReason = exception.reason ?? "Unknown Error setApplicationIconBadgNumber"
                                 print("\(errorReason)")
                                 result(
                                     FlutterError(
@@ -94,7 +94,7 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
                                     result(nil)
                                 }
                             } catch: { (exception) in
-                                let errorReason = exception?.reason ?? "Unknown Error setApplicationIconBadgeNumber"
+                                let errorReason = exception.reason ?? "Unknown Error setApplicationIconBadgeNumber"
                                 print("\(errorReason)")
                                 result(
                                     FlutterError(
@@ -124,7 +124,7 @@ public class FlutterDynamicIconPlusPlugin: NSObject, FlutterPlugin {
                     UIApplication.shared.applicationIconBadgeNumber = batchIconNumber
                     result(nil)
                 } catch: { (exception) in
-                    let errorReason = exception?.reason ?? "Unknown Error setApplicationIconBadgeNumber"
+                    let errorReason = exception.reason ?? "Unknown Error setApplicationIconBadgeNumber"
                     print(errorReason)
                     result(
                         FlutterError(


### PR DESCRIPTION
## Summary

iOS builds fail on recent Xcode / Swift toolchains (verified on Xcode 26.5 / iOS 26.5 SDK) with:

```
Cannot use optional chaining on non-optional value of type 'NSException'
  at ios/Classes/FlutterDynamicIconPlusPlugin.swift:45 (and 77, 97, 127)
```

The `SwiftTryCatch.try { } catch: { (exception) in ... }` closure now imports the `NSException` parameter as **non-optional**, so `exception?.reason` no longer type-checks.

This PR is a minimal 4-line patch that drops the `?.` on each call site. `NSException.reason` is itself still `String?`, so the `?? "Unknown Error ..."` fallback is preserved and runtime behavior is unchanged.

## Why a separate PR from #26

[PR #26](https://github.com/chandrabezzo/flutter_dynamic_icon_plus/pull/26) takes a different (larger) approach — removing `SwiftTryCatch` entirely. That's a defensible direction, but until it lands, this minimally invasive patch unblocks every iOS project hitting the build failure on Xcode 26+ without changing the plugin's error-handling strategy. Happy to close this if #26 ships first.

## Test plan
- [x] Verified the patched plugin compiles cleanly against Xcode 26.5 / iOS 26.5 simulator (iPhone 17).
- [x] Verified the existing `?? "Unknown Error ..."` fallback still triggers when `NSException.reason` is nil (no runtime behavior change).